### PR TITLE
Allow setting an email for the magic login instead of always opening …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tenkeylabs/wagmi-magic-connector",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "wagmi connector to connect with Magic SDK",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/connectors/magicAuthConnector.ts
+++ b/src/lib/connectors/magicAuthConnector.ts
@@ -47,6 +47,8 @@ export class MagicAuthConnector extends MagicConnector {
 
   redirectUrl?: string;
 
+  email?: string;
+
   constructor(config: { chains?: Chain[]; options: MagicAuthOptions }) {
     super(config);
     this.magicSdkConfiguration = config.options.magicSdkConfiguration;
@@ -55,6 +57,10 @@ export class MagicAuthConnector extends MagicConnector {
     this.enableSMSLogin = config.options.enableSMSLogin;
     this.enableEmailLogin = config.options.enableEmailLogin;
     this.redirectUrl = config.options.redirectURI;
+  }
+
+  setEmail(email: string) {
+    this.email = email;
   }
 
   async connect(_config?: {
@@ -92,14 +98,20 @@ export class MagicAuthConnector extends MagicConnector {
         };
       }
 
-      // open the modal and process the magic login steps
-      if (!this.isModalOpen) {
+      const magic = this.getMagicSDK();
+      if (this.email) {
+        // An email has already been set, so use it to log in
+        await magic.auth.loginWithMagicLink({
+          email: this.email,
+          redirectURI: this.redirectUrl,
+        });
+      } else if (!this.isModalOpen) {
+        // open the modal and process the magic login steps
         const output = await this.getUserDetailsByForm(
           this.enableSMSLogin,
           this.enableEmailLogin,
           this.oauthProviders
         );
-        const magic = this.getMagicSDK();
 
         // LOGIN WITH MAGIC LINK WITH OAUTH PROVIDER
         if (output.oauthProvider) {
@@ -123,7 +135,9 @@ export class MagicAuthConnector extends MagicConnector {
             phoneNumber: output.phoneNumber,
           });
         }
+      }
 
+      if (magic.user.isLoggedIn()) {
         const metadata = await magic.user.getMetadata();
         this.address = getAddress(metadata.publicAddress);
 
@@ -162,5 +176,10 @@ export class MagicAuthConnector extends MagicConnector {
       return this.magicSDK;
     }
     return this.magicSDK;
+  }
+
+  async disconnect(): Promise<void> {
+    this.email = undefined;
+    super.disconnect();
   }
 }

--- a/src/lib/connectors/magicConnector.ts
+++ b/src/lib/connectors/magicConnector.ts
@@ -6,7 +6,6 @@ import { Address, Chain, Connector, normalizeChainId } from '@wagmi/core';
 import { ethers, Signer } from 'ethers';
 import { getAddress } from 'ethers/lib/utils';
 import type { AbstractProvider } from 'web3-core';
-
 import { createModal } from '../modal/view';
 
 const IS_SERVER = typeof window === 'undefined';


### PR DESCRIPTION
…the modal

This allows the users to avoid having to go through the modal flow and can instead pass in the login email to the connector.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
