### PR TITLE
Update the wagmi connector provider and signer caching

### DIFF
--- a/.changeset/afraid-beds-complain.md
+++ b/.changeset/afraid-beds-complain.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/wagmi-magic-connector': patch
+---
+
+Cache the ethers provider and signer used by the magic connector.


### PR DESCRIPTION
Switch to caching the ethers provider instead of the magic web3 provider. This eliminates the need to always create an ethers Provider.

Add caching for the signer.

Reset the provider and signer on logout.

Bump to version 0.0.7
