### PR TITLE
outputs esm instead of commonjs

### DIFF
--- a/.changeset/fluffy-dragons-dance.md
+++ b/.changeset/fluffy-dragons-dance.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/wagmi-magic-connector": patch
+---
+
+outputs esm instead of commonjs

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "build/main",
     "rootDir": "src",
     "moduleResolution": "node",
-    "module": "commonjs",
+    "module": "ESNext",
     "declaration": true,
     "inlineSourceMap": true,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
this aligns build output with the other wagmi connectors.

- **What is the current behavior?** (You can also link to an open issue here)
currently, the connector outputs as commonjs
